### PR TITLE
minor command changes in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@
 Запуск докера::
 
   docker run --rm  \
-           --volume PATH_TO_YOUR_REPO:/home/ubuntu/repo:ro   \
+           --volume PATH_TO_YOUR_REPO:/home/ubuntu/repo:rw   \
            --volume PATH_TO_CONAN_CACHE:/home/ubuntu/.conan2/:rw \
            -it cpp-build
 
@@ -47,11 +47,12 @@
 
 Для запуска clang-format::
 
-  cd repo
+  cd repo/src
   find . -iname "*.h" -o -iname "*.hpp" -o -iname "*.cpp" -exec clang-format --dry-run --Werror -style=file {} +
 
 Для сборки и запуска тестов без санитайзеров::
 
+  cd repo
   mkdir build
   cmake -S. -Bbuild -DUSE_CLANG_TIDY=TRUE -DTESTS_BUILD_TYPE=NONE -DCMAKE_BUILD_TYPE=Release
   cmake --build build
@@ -59,6 +60,7 @@
 
 Для сборки и запуска тестов c ASAN::
 
+  cd repo
   mkdir build_ASAN
   cmake -S. -Bbuild_ASAN -DTESTS_BUILD_TYPE=ASAN -DCMAKE_BUILD_TYPE=Debug
   cmake --build build_ASAN


### PR DESCRIPTION
1. При запуске докера с аттрибутом раздела `ro`  выполнение последующих команд (будь то создание директории, или билд исходников) становится невозможным. Заменено на `rw`

2. При запуске clang-format из директории `repo`, clang-format также проверяет все остальные файлы с подходящими расширениями (например, файлы CMake), полностью заполняя консоль. 
Решения 2: 
        1. Прописать точное название файла `calc.cpp`, или иного, для тестирования других файлов
        2. Запускать команду из директории `repo/src`, чтобы проверять только файлы, относящися к решению
В коммите принято второе, оставляющее оригинальную комманду неизменное
3. Перемещение внутри докера в директорию репозитория перед запуском тестов